### PR TITLE
Move coffee-script to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
     "glob": "~3.1.21",
     "baconjs": "~0.1.7",
     "gaze": "~0.3.3",
-    "mkdirp": "~0.3.5"
+    "mkdirp": "~0.3.5",
+    "coffee-script": "~1.6.1"
   },
   "bin": {
     "james": "bin/james"
   },
   "preferGlobal": true,
   "devDependencies": {
-    "coffee-script": "~1.6.1",
     "mocha": "~1.8.1"
   }
 }


### PR DESCRIPTION
In order to support Jamesfiles written in CoffeeScript,
one must have coffee-script installed
