### PR TITLE
Shorthand forms for james.watch

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,23 @@ exports.list = function() {
 };
 
 exports.watch = function(pattern, cb) {
+  var tasks;
+
+  if (typeof cb === 'string') {
+    tasks = cb;
+    cb = function() {
+      exports.run(tasks);
+    };
+  }
+  else if (Array.isArray(cb)) {
+    tasks = cb;
+    cb = function() {
+      tasks.forEach(function(task) {
+        exports.run(task);
+      });
+    };
+  }
+
   Q.nfcall(gaze, pattern)
   .then(function(watcher) {
     watcher.on('all', function(event, file) {

--- a/test/test.js
+++ b/test/test.js
@@ -62,6 +62,41 @@ describe('james', function(){
       },
         1000);
     });
+
+    it('should run the named task if the callback is a string', function(done){
+      james.task('foo', function(){
+        done();
+      });
+
+      james.watch('test/**/*.js', 'foo');
+
+      setTimeout(function(){
+        var now = new Date();
+        fs.utimesSync(file, now, now);
+      },
+        1000);
+    });
+
+    it('should run the listed tasks if the callback is an array', function(done){
+      var foo = false;
+
+      james.task('foo', function(){
+        foo = true;
+      });
+
+      james.task('bar', function(){
+        assert(foo);
+        done();
+      });
+
+      james.watch('test/**/*.js', ['foo', 'bar']);
+
+      setTimeout(function(){
+        var now = new Date();
+        fs.utimesSync(file, now, now);
+      },
+        1000);
+    });
   });
 
   describe('#read', function(){


### PR DESCRIPTION
Implemented the two following shorthand forms for james.watch. Tests included.

```
// Run the named task when the watched file changes
james.watch('test/**/*.js', 'foo');

// Run the listed tasks when the watched file changes
james.watch('test/**/*.js', ['foo', 'bar']);
```
